### PR TITLE
fix: webview property editor outputs fixed string to xaf log

### DIFF
--- a/src/Xenial.Framework.WebView.Blazor/Editors/WebViewHtmlStringPropertyEditor.cs
+++ b/src/Xenial.Framework.WebView.Blazor/Editors/WebViewHtmlStringPropertyEditor.cs
@@ -51,6 +51,10 @@ namespace Xenial.Framework.WebView.Blazor.Editors
         {
             //DataSource = (Model.PredefinedValues ?? string.Empty).Split(";").ToList()
         });
+
+        /// <inheritdoc />
+        /// <remarks>We don't run base to avoid outputting the full html value to the log.</remarks>
+        protected override void LogValueStoring(object newValue) => DevExpress.Persistent.Base.Tracing.Tracer.LogText($"{nameof(WebViewHtmlStringPropertyEditor)} value changed.");
     }
 
     /// <summary>

--- a/src/Xenial.Framework.WebView.Win/Editors/WebViewHtmlStringPropertyEditor.cs
+++ b/src/Xenial.Framework.WebView.Win/Editors/WebViewHtmlStringPropertyEditor.cs
@@ -91,6 +91,10 @@ namespace Xenial.Framework.WebView.Win.Editors
         /// </value>
 
         public new XenialHtmlStringWebView2 Control => (XenialHtmlStringWebView2)base.Control;
+
+        /// <inheritdoc />
+        /// <remarks>We don't run base to avoid outputting the full html value to the log.</remarks>
+        protected override void LogValueStoring(object newValue) => DevExpress.Persistent.Base.Tracing.Tracer.LogText($"{nameof(WebViewHtmlStringPropertyEditor)} value changed.");
     }
 
     /// <summary>


### PR DESCRIPTION
Instead of outputting to the xaf log the full html of the editor value, it will output this fixed string:
`WebViewHtmlStringPropertyEditor value changed.`

Fixes #59