### PR TITLE
Added NuGet package tags

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <NoWarn>VSTHRD200;CA1014;CA5392;CA1200;CS1658;CS1584;CA1200;IDE0079;$(NoWarn)</NoWarn>
-    <PackageTags>Xenial, Tasty, Testing, Tasting, UnitTasting, IntegrationTasting, xUnit, NUnit, MSTest, UnitTest, IntegrationTest, BDD, TDD, Jest</PackageTags>
+    <PackageTags>Xenial Framework eXpressApp DevExpress XAF</PackageTags>
     <XenialPublicKey Condition="$(XenialPublicKey) == ''"></XenialPublicKey>
     <CheckXenialLicense>false</CheckXenialLicense>
     <_XenialLicGenVersion Condition="$(XenialLicGenVersion) != ''">[$(XenialLicGenVersion)]</_XenialLicGenVersion>

--- a/src/Xenial.Framework.Badges.Blazor/Xenial.Framework.Badges.Blazor.csproj
+++ b/src/Xenial.Framework.Badges.Blazor/Xenial.Framework.Badges.Blazor.csproj
@@ -5,6 +5,7 @@
     <DxExtendStartupHost>false</DxExtendStartupHost>
     <RazorLangVersion>$(RazorLangVersion)</RazorLangVersion>
     <NoWarn>$(NoWarn);NU5118</NoWarn> <!-- Duplicate wwwroot files with netstandard2.1 and net5.0 -->
+    <PackageTags>$(PackageTags) Badges Blazor</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.Badges.Win/Xenial.Framework.Badges.Win.csproj
+++ b/src/Xenial.Framework.Badges.Win/Xenial.Framework.Badges.Win.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(XenialWinTFMs)</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <PackageTags>$(PackageTags) Badges Win Adorner</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.Badges/Xenial.Framework.Badges.csproj
+++ b/src/Xenial.Framework.Badges/Xenial.Framework.Badges.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageTags>$(PackageTags) Badges Agnostic</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.Blazor/Xenial.Framework.Blazor.csproj
+++ b/src/Xenial.Framework.Blazor/Xenial.Framework.Blazor.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(XenialBlazorTFMs)</TargetFrameworks>
     <DxExtendStartupHost>false</DxExtendStartupHost>
     <RazorLangVersion>$(RazorLangVersion)</RazorLangVersion>
+    <PackageTags>$(PackageTags) Blazor</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.LabelEditors.Win/Xenial.Framework.LabelEditors.Win.csproj
+++ b/src/Xenial.Framework.LabelEditors.Win/Xenial.Framework.LabelEditors.Win.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(XenialWinTFMs)</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <PackageTags>$(PackageTags) PropertyEditor LabelEditors Win XtraEditors HyperlinkLabelControl LabelControl</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.LabelEditors/Xenial.Framework.LabelEditors.csproj
+++ b/src/Xenial.Framework.LabelEditors/Xenial.Framework.LabelEditors.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageTags>$(PackageTags) PropertyEditor LabelEditors Agnostic</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.StepProgressEditors.Win/Xenial.Framework.StepProgressEditors.Win.csproj
+++ b/src/Xenial.Framework.StepProgressEditors.Win/Xenial.Framework.StepProgressEditors.Win.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(XenialWinTFMs)</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <PackageTags>$(PackageTags) PropertyEditor StepProgress Win XtraEditors StepProgressBar</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.StepProgressEditors/Xenial.Framework.StepProgressEditors.csproj
+++ b/src/Xenial.Framework.StepProgressEditors/Xenial.Framework.StepProgressEditors.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageTags>$(PackageTags) PropertyEditor StepProgress Agnostic</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.TokenEditors.Blazor/Xenial.Framework.TokenEditors.Blazor.csproj
+++ b/src/Xenial.Framework.TokenEditors.Blazor/Xenial.Framework.TokenEditors.Blazor.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(NetBlazorLibVersion)</TargetFrameworks>
     <DxExtendStartupHost>false</DxExtendStartupHost>
     <RazorLangVersion>$(RazorLangVersion)</RazorLangVersion>
+    <PackageTags>$(PackageTags) PropertyEditor TokenEditors Blazor</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.TokenEditors.Win/Xenial.Framework.TokenEditors.Win.csproj
+++ b/src/Xenial.Framework.TokenEditors.Win/Xenial.Framework.TokenEditors.Win.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(XenialWinTFMs)</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <PackageTags>$(PackageTags) PropertyEditor TokenEditors Win XtraEditors TokenEdit</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.TokenEditors/Xenial.Framework.TokenEditors.csproj
+++ b/src/Xenial.Framework.TokenEditors/Xenial.Framework.TokenEditors.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageTags>$(PackageTags) PropertyEditor TokenEditors Agnostic</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.WebView.Blazor/Xenial.Framework.WebView.Blazor.csproj
+++ b/src/Xenial.Framework.WebView.Blazor/Xenial.Framework.WebView.Blazor.csproj
@@ -5,6 +5,7 @@
     <DxExtendStartupHost>false</DxExtendStartupHost>
     <RazorLangVersion>$(RazorLangVersion)</RazorLangVersion>
     <NoWarn>NU5118;$(NoWarn)</NoWarn>
+    <PackageTags>$(PackageTags) PropertyEditor WebView Browser Edge Chromium Blazor</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.WebView.Win/Xenial.Framework.WebView.Win.csproj
+++ b/src/Xenial.Framework.WebView.Win/Xenial.Framework.WebView.Win.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(XenialWinTFMs)</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <PackageTags>$(PackageTags) PropertyEditor WebView Browser Edge Chromium Win WebView2</PackageTags>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Xenial.Framework.WebView/Xenial.Framework.WebView.csproj
+++ b/src/Xenial.Framework.WebView/Xenial.Framework.WebView.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageTags>$(PackageTags) PropertyEditor WebView Browser Edge Chromium Agnostic</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.Win/Xenial.Framework.Win.csproj
+++ b/src/Xenial.Framework.Win/Xenial.Framework.Win.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(XenialWinTFMs)</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <PackageTags>$(PackageTags) Win</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xenial.Framework.Xpo/Xenial.Framework.Xpo.csproj
+++ b/src/Xenial.Framework.Xpo/Xenial.Framework.Xpo.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <PackageTags>$(PackageTags) XPO</PackageTags>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="DevExpress.ExpressApp.Xpo" Version="$(DxPackageVersion)" />
   </ItemGroup>

--- a/src/Xenial.Framework/Xenial.Framework.csproj
+++ b/src/Xenial.Framework/Xenial.Framework.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <NoWarn>CA1716;$(NoWarn)</NoWarn>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <PackageTags>$(PackageTags) Agnostic</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaced the base package tags for the Xenial framework. All unset packages will default to:
`PackageTags>Xenial Framework eXpressApp DevExpress XAF</PackageTags>`

Sub packages like the editors have additional tag to specify the platform and related editor.

Fixes #76 